### PR TITLE
Add GitHub Pages bookshelf site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .obsidian/
 .DS_Store
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Obsidian Notes – Bookshelf
+
+This repository contains long-form research notes and two in-progress books:
+
+- **Color Correction**
+- **Object Detection**
+
+To make the material easier to browse, the repository now includes a GitHub
+Pages site that renders the Markdown chapters directly in the browser using
+[Marked](https://marked.js.org/).
+
+## Publishing to GitHub Pages
+
+1. Push the latest changes to the `main` branch.
+2. In the GitHub repository settings, open **Pages**.
+3. Set the **Source** to `Deploy from a branch` → `main` → `/ (root)`.
+4. Save the settings. GitHub will publish the site at `https://<username>.github.io/<repository>/`.
+
+Because the site is built entirely from static HTML, CSS, and JavaScript, no
+additional build step is required once Pages is enabled.
+
+## Updating the navigation
+
+The navigation sidebar is generated from `books.json`, which is produced by a
+small helper script. Run the script whenever you add new chapters or rename
+files:
+
+```bash
+python3 scripts/generate_books_index.py
+```
+
+Commit the updated `books.json` file alongside your content changes to keep the
+site in sync with the repository.
+
+## Local preview
+
+You can preview the site locally before publishing by launching a simple HTTP
+server from the repository root:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open <http://localhost:8000> in your browser.

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,219 @@
+const state = {
+  books: [],
+  activePath: null,
+};
+
+const navigationEl = document.getElementById("book-navigation");
+const contentEl = document.getElementById("book-content");
+const mainEl = document.getElementById("main");
+const navRegistry = new Map();
+
+if (window.marked) {
+  window.marked.setOptions({
+    breaks: false,
+    gfm: true,
+    mangle: false,
+    headerIds: true,
+  });
+}
+
+async function init() {
+  try {
+    const books = await loadBooks();
+    state.books = books;
+    if (books.length === 0) {
+      renderNavigationPlaceholder("No book directories were found. Add folders that start with ‘Book_’.");
+      renderContentMessage("No content to display yet.");
+      return;
+    }
+
+    buildNavigation(books);
+    const initialPath = decodeHash(location.hash) || firstChapterPath(books);
+    if (initialPath) {
+      // Use replaceState so that the initial load does not add an extra entry.
+      updateHash(initialPath, { replace: true });
+      await displayChapter(initialPath);
+    }
+  } catch (error) {
+    console.error(error);
+    renderNavigationPlaceholder("Unable to load book metadata. Ensure books.json exists.");
+    renderError(String(error));
+  }
+}
+
+async function loadBooks() {
+  const response = await fetch("books.json", { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`books.json could not be loaded (HTTP ${response.status})`);
+  }
+  return response.json();
+}
+
+function buildNavigation(books) {
+  navigationEl.innerHTML = "";
+  navRegistry.clear();
+
+  books.forEach((book, bookIndex) => {
+    const bookContainer = document.createElement("div");
+    bookContainer.className = "book";
+
+    const bookHeader = document.createElement("h3");
+    bookHeader.textContent = book.title;
+    bookContainer.appendChild(bookHeader);
+
+    book.sections.forEach((section, sectionIndex) => {
+      const details = document.createElement("details");
+      details.className = "section";
+      if (bookIndex === 0 && sectionIndex === 0) {
+        details.open = true;
+      }
+
+      const summary = document.createElement("summary");
+      summary.textContent = section.title;
+      details.appendChild(summary);
+
+      const list = document.createElement("ul");
+      section.items.forEach((item) => {
+        const listItem = document.createElement("li");
+        const link = document.createElement("a");
+        link.href = `#${encodeURIComponent(item.path)}`;
+        link.textContent = item.title;
+        link.dataset.path = item.path;
+        link.addEventListener("click", (event) => {
+          event.preventDefault();
+          navigateToChapter(item.path);
+        });
+        listItem.appendChild(link);
+        list.appendChild(listItem);
+
+        navRegistry.set(item.path, { link, details });
+      });
+
+      details.appendChild(list);
+      bookContainer.appendChild(details);
+    });
+
+    navigationEl.appendChild(bookContainer);
+  });
+}
+
+function navigateToChapter(path) {
+  if (!path) return;
+  updateHash(path, { replace: false });
+}
+
+function updateHash(path, { replace }) {
+  const encoded = `#${encodeURIComponent(path)}`;
+  if (replace) {
+    history.replaceState(null, "", encoded);
+  } else {
+    if (location.hash === encoded) {
+      // Trigger hashchange manually because browsers do not emit it when the value is unchanged.
+      handleHashChange();
+    } else {
+      location.hash = encoded;
+    }
+  }
+}
+
+function decodeHash(hash) {
+  if (!hash || hash.length <= 1) return "";
+  try {
+    return decodeURIComponent(hash.slice(1));
+  } catch (error) {
+    console.warn("Unable to decode hash", hash, error);
+    return "";
+  }
+}
+
+async function displayChapter(path) {
+  if (!path) return;
+  const registryEntry = navRegistry.get(path);
+  if (!registryEntry) {
+    renderError("The requested chapter is not part of the current index.");
+    return;
+  }
+
+  setActiveLink(path, registryEntry);
+  await loadChapter(path);
+}
+
+function setActiveLink(path, entry) {
+  if (state.activePath && navRegistry.has(state.activePath)) {
+    const previous = navRegistry.get(state.activePath);
+    previous.link.classList.remove("active");
+  }
+
+  state.activePath = path;
+  entry.link.classList.add("active");
+  entry.details.open = true;
+  entry.link.scrollIntoView({ block: "nearest", behavior: "smooth" });
+}
+
+async function loadChapter(path) {
+  renderLoading();
+  try {
+    const response = await fetch(encodeURI(path));
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    let markdown = await response.text();
+    markdown = stripFrontMatter(markdown);
+    const html = window.marked ? window.marked.parse(markdown) : markdown;
+    contentEl.innerHTML = html;
+    try {
+      mainEl.focus({ preventScroll: true });
+    } catch (error) {
+      mainEl.focus();
+    }
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  } catch (error) {
+    renderError(`Unable to load the selected chapter. ${error.message}`);
+  }
+}
+
+function stripFrontMatter(markdown) {
+  if (markdown.startsWith("---")) {
+    const match = markdown.match(/^---[\s\S]*?\n---\s*\n?/);
+    if (match) {
+      return markdown.slice(match[0].length);
+    }
+  }
+  return markdown;
+}
+
+function renderLoading() {
+  contentEl.innerHTML = '<div class="status-message">Loading chapter…</div>';
+}
+
+function renderError(message) {
+  contentEl.innerHTML = `<div class="status-message error"><strong>Something went wrong.</strong><br>${message}</div>`;
+}
+
+function renderNavigationPlaceholder(message) {
+  navigationEl.innerHTML = `<div class="status-message error">${message}</div>`;
+}
+
+function renderContentMessage(message) {
+  contentEl.innerHTML = `<div class="status-message">${message}</div>`;
+}
+
+function firstChapterPath(books) {
+  for (const book of books) {
+    for (const section of book.sections) {
+      if (section.items && section.items.length > 0) {
+        return section.items[0].path;
+      }
+    }
+  }
+  return "";
+}
+
+function handleHashChange() {
+  const path = decodeHash(location.hash);
+  if (!path) return;
+  displayChapter(path);
+}
+
+window.addEventListener("hashchange", handleHashChange);
+document.addEventListener("DOMContentLoaded", init);

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,299 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7f9;
+  --bg-alt: #ffffff;
+  --border: #d6dae1;
+  --text: #1f2933;
+  --text-muted: #52606d;
+  --accent: #4f46e5;
+  --accent-soft: rgba(79, 70, 229, 0.1);
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header {
+  background: var(--bg-alt);
+  border-bottom: 1px solid var(--border);
+  padding: 2rem 3rem 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.header-content {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2.5rem;
+}
+
+.tagline {
+  margin: 0.5rem 0 0;
+  color: var(--text-muted);
+  font-size: 1.05rem;
+}
+
+.layout {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 0;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.sidebar {
+  position: sticky;
+  top: 1.5rem;
+  align-self: start;
+}
+
+.sidebar-inner {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  max-height: calc(100vh - 4rem);
+  overflow: auto;
+}
+
+.sidebar-intro h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.sidebar-intro p {
+  margin: 0.5rem 0 1.25rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.book-navigation {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.book {
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+}
+
+.book:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.book > h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.section {
+  margin-top: 0.75rem;
+}
+
+.section summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-muted);
+  list-style: none;
+}
+
+.section summary::marker {
+  display: none;
+}
+
+.section summary::-webkit-details-marker {
+  display: none;
+}
+
+.section summary::after {
+  content: "▾";
+  float: right;
+  transition: transform 0.2s ease;
+}
+
+.section[open] summary::after {
+  transform: rotate(-180deg);
+}
+
+.section ul {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.section a {
+  display: block;
+  text-decoration: none;
+  color: var(--text);
+  font-size: 0.95rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.section a:hover,
+.section a:focus {
+  background: var(--accent-soft);
+  color: var(--accent);
+  outline: none;
+}
+
+.section a.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.main-content {
+  padding-left: 2rem;
+}
+
+.book-content {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+  min-height: calc(100vh - 8rem);
+  overflow: hidden;
+}
+
+.book-content h1,
+.book-content h2,
+.book-content h3 {
+  color: var(--text);
+}
+
+.book-content h1 {
+  font-size: 2rem;
+}
+
+.book-content h2 {
+  font-size: 1.5rem;
+}
+
+.book-content h3 {
+  font-size: 1.25rem;
+}
+
+.book-content p {
+  line-height: 1.7;
+  margin: 1rem 0;
+  color: var(--text);
+}
+
+.book-content ul,
+.book-content ol {
+  padding-left: 1.25rem;
+}
+
+.book-content pre {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 1rem;
+  border-radius: 12px;
+  overflow: auto;
+}
+
+.book-content code {
+  background: rgba(15, 23, 42, 0.07);
+  padding: 0.2rem 0.35rem;
+  border-radius: 6px;
+  font-family: "Fira Code", "Source Code Pro", monospace;
+  font-size: 0.9rem;
+}
+
+.placeholder {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 3rem 1rem;
+}
+
+.status-message {
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.status-message.error {
+  background: rgba(220, 38, 38, 0.1);
+  color: #991b1b;
+}
+
+.page-footer {
+  background: var(--bg-alt);
+  border-top: 1px solid var(--border);
+  padding: 1.5rem 3rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.page-footer a {
+  color: var(--accent);
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+    padding: 1rem;
+  }
+
+  .sidebar {
+    position: static;
+  }
+
+  .sidebar-inner {
+    max-height: none;
+  }
+
+  .main-content {
+    padding: 1.5rem 0 0;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b1220;
+    --bg-alt: #111827;
+    --border: #1f2937;
+    --text: #e5e7eb;
+    --text-muted: #9ca3af;
+    --accent: #818cf8;
+    --accent-soft: rgba(129, 140, 248, 0.16);
+    --shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  .book-content pre {
+    background: #1e293b;
+    color: #f8fafc;
+  }
+
+  .book-content code {
+    background: rgba(148, 163, 184, 0.12);
+  }
+}

--- a/books.json
+++ b/books.json
@@ -1,0 +1,223 @@
+[
+  {
+    "title": "Color Correction",
+    "path": "Book_Color_Correction",
+    "sections": [
+      {
+        "title": "Overview",
+        "items": [
+          {
+            "title": "Deep Research",
+            "path": "Book_Color_Correction/DeepResearch.md"
+          },
+          {
+            "title": "Table of Contents",
+            "path": "Book_Color_Correction/TableOfContents.md"
+          }
+        ]
+      },
+      {
+        "title": "Part I: The Foundations of Color Science",
+        "items": [
+          {
+            "title": "Chapter 1 \u2013 The Physics and Physiology of Color Perception",
+            "path": "Book_Color_Correction/Part_I_The_Foundations_of_Color_Science/Chapter_1_The_Physics_and_Physiology_of_Color_Perception/Chapter_1.md"
+          },
+          {
+            "title": "Chapter 2 \u2013 Color Theory and Abstract Models",
+            "path": "Book_Color_Correction/Part_I_The_Foundations_of_Color_Science/Chapter_2_Color_Theory_and_Abstract_Models/Chapter_2.md"
+          },
+          {
+            "title": "Chapter 3 \u2013 Quantifying Color Color Spaces and Models",
+            "path": "Book_Color_Correction/Part_I_The_Foundations_of_Color_Science/Chapter_3_Quantifying_Color_Color_Spaces_and_Models/Chapter_3.md"
+          }
+        ]
+      },
+      {
+        "title": "Part II: The Digital Color Correction Toolkit",
+        "items": [
+          {
+            "title": "Chapter 4 \u2013 Capturing Color The Digital Imaging Pipeline",
+            "path": "Book_Color_Correction/Part_II_The_Digital_Color_Correction_Toolkit/Chapter_4_Capturing_Color_The_Digital_Imaging_Pipeline/Chapter_4.md"
+          },
+          {
+            "title": "Chapter 5 \u2013 Analyzing Color Scopes and Histograms",
+            "path": "Book_Color_Correction/Part_II_The_Digital_Color_Correction_Toolkit/Chapter_5_Analyzing_Color_Scopes_and_Histograms/Chapter_5.md"
+          },
+          {
+            "title": "Chapter 6 \u2013 Manipulating Color Core Correction Techniques",
+            "path": "Book_Color_Correction/Part_II_The_Digital_Color_Correction_Toolkit/Chapter_6_Manipulating_Color_Core_Correction_Techniques/Chapter_6.md"
+          }
+        ]
+      },
+      {
+        "title": "Part III: Professional Workflows and Color Management",
+        "items": [
+          {
+            "title": "Chapter 7 \u2013 Color Correction for Still Photography",
+            "path": "Book_Color_Correction/Part_III_Professional_Workflows_and_Color_Management/Chapter_7_Color_Correction_for_Still_Photography/Chapter_7.md"
+          },
+          {
+            "title": "Chapter 8 \u2013 Color Grading for Cinematography",
+            "path": "Book_Color_Correction/Part_III_Professional_Workflows_and_Color_Management/Chapter_8_Color_Grading_for_Cinematography/Chapter_8.md"
+          },
+          {
+            "title": "Chapter 9 \u2013 Color Standards for Broadcast and Print",
+            "path": "Book_Color_Correction/Part_III_Professional_Workflows_and_Color_Management/Chapter_9_Color_Standards_for_Broadcast_and_Print/Chapter_9.md"
+          }
+        ]
+      },
+      {
+        "title": "Part IV: Advanced Color Mapping and Transformation",
+        "items": [
+          {
+            "title": "Chapter 10 \u2013 High Dynamic Range HDR and Tone Mapping",
+            "path": "Book_Color_Correction/Part_IV_Advanced_Color_Mapping_and_Transformation/Chapter_10_High_Dynamic_Range_HDR_and_Tone_Mapping/Chapter_10.md"
+          },
+          {
+            "title": "Chapter 11 \u2013 Bridging Devices Gamut Mapping",
+            "path": "Book_Color_Correction/Part_IV_Advanced_Color_Mapping_and_Transformation/Chapter_11_Bridging_Devices_Gamut_Mapping/Chapter_11.md"
+          },
+          {
+            "title": "Chapter 12 \u2013 The Power of Presets 3D Look Up Tables LUTs",
+            "path": "Book_Color_Correction/Part_IV_Advanced_Color_Mapping_and_Transformation/Chapter_12_The_Power_of_Presets_3D_Look_Up_Tables_LUTs/Chapter_12.md"
+          }
+        ]
+      },
+      {
+        "title": "Part V: The Future of Color Automation and AI",
+        "items": [
+          {
+            "title": "Chapter 13 \u2013 Algorithmic Color Transfer and Style Emulation",
+            "path": "Book_Color_Correction/Part_V_The_Future_of_Color_Automation_and_AI/Chapter_13_Algorithmic_Color_Transfer_and_Style_Emulation/Chapter_13.md"
+          },
+          {
+            "title": "Chapter 14 \u2013 The Rise of AI in Color Correction",
+            "path": "Book_Color_Correction/Part_V_The_Future_of_Color_Automation_and_AI/Chapter_14_The_Rise_of_AI_in_Color_Correction/Chapter_14.md"
+          },
+          {
+            "title": "Chapter 15 \u2013 Emerging Frontiers and Future Challenges",
+            "path": "Book_Color_Correction/Part_V_The_Future_of_Color_Automation_and_AI/Chapter_15_Emerging_Frontiers_and_Future_Challenges/Chapter_15.md"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "Object Detection",
+    "path": "Book_Object_Detection",
+    "sections": [
+      {
+        "title": "Overview",
+        "items": [
+          {
+            "title": "Chapter Outline",
+            "path": "Book_Object_Detection/Chapter_Outline.md"
+          },
+          {
+            "title": "Section Template",
+            "path": "Book_Object_Detection/Section_Template.md"
+          }
+        ]
+      },
+      {
+        "title": "Part 1: Foundations",
+        "items": [
+          {
+            "title": "Chapter 01 \u2013 A Journey into Seeing Machines",
+            "path": "Book_Object_Detection/Part_1_Foundations/Chapter_01_A_Journey_into_Seeing_Machines/Chapter_01.md"
+          },
+          {
+            "title": "Chapter 02 \u2013 The Building Blocks",
+            "path": "Book_Object_Detection/Part_1_Foundations/Chapter_02_The_Building_Blocks/Chapter_02.md"
+          }
+        ]
+      },
+      {
+        "title": "Part 2: Object Detection",
+        "items": [
+          {
+            "title": "Chapter 03 \u2013 Early Approaches to Object Localization",
+            "path": "Book_Object_Detection/Part_2_Object_Detection/Chapter_03_Early_Approaches_to_Object_Localization/Chapter_03.md"
+          },
+          {
+            "title": "Chapter 04 \u2013 The R-CNN Family",
+            "path": "Book_Object_Detection/Part_2_Object_Detection/Chapter_04_The_R-CNN_Family/Chapter_04.md"
+          },
+          {
+            "title": "Chapter 05 \u2013 Real-Time Detection",
+            "path": "Book_Object_Detection/Part_2_Object_Detection/Chapter_05_Real-Time_Detection/Chapter_05.md"
+          },
+          {
+            "title": "Chapter 06 \u2013 Beyond Bounding Boxes Modern Detection Architectures",
+            "path": "Book_Object_Detection/Part_2_Object_Detection/Chapter_06_Beyond_Bounding_Boxes_Modern_Detection_Architectures/Chapter_06.md"
+          }
+        ]
+      },
+      {
+        "title": "Part 3: Segmentation and Matting",
+        "items": [
+          {
+            "title": "Chapter 07 \u2013 Semantic Segmentation",
+            "path": "Book_Object_Detection/Part_3_Segmentation_and_Matting/Chapter_07_Semantic_Segmentation/Chapter_07.md"
+          },
+          {
+            "title": "Chapter 08 \u2013 Instance Segmentation",
+            "path": "Book_Object_Detection/Part_3_Segmentation_and_Matting/Chapter_08_Instance_Segmentation/Chapter_08.md"
+          },
+          {
+            "title": "Chapter 09 \u2013 Image Matting",
+            "path": "Book_Object_Detection/Part_3_Segmentation_and_Matting/Chapter_09_Image_Matting/Chapter_09.md"
+          }
+        ]
+      },
+      {
+        "title": "Part 4: Tracking in Videos",
+        "items": [
+          {
+            "title": "Chapter 10 \u2013 Introduction to Multi-Object Tracking",
+            "path": "Book_Object_Detection/Part_4_Tracking_in_Videos/Chapter_10_Introduction_to_Multi-Object_Tracking/Chapter_10.md"
+          },
+          {
+            "title": "Chapter 11 \u2013 The Evolution of Tracking-by-Detection",
+            "path": "Book_Object_Detection/Part_4_Tracking_in_Videos/Chapter_11_The_Evolution_of_Tracking-by-Detection/Chapter_11.md"
+          },
+          {
+            "title": "Chapter 12 \u2013 New Frontiers in Tracking",
+            "path": "Book_Object_Detection/Part_4_Tracking_in_Videos/Chapter_12_New_Frontiers_in_Tracking/Chapter_12.md"
+          }
+        ]
+      },
+      {
+        "title": "Part 5: Advanced Topics",
+        "items": [
+          {
+            "title": "Chapter 13 \u2013 Learning from Less",
+            "path": "Book_Object_Detection/Part_5_Advanced_Topics/Chapter_13_Learning_from_Less/Chapter_13.md"
+          },
+          {
+            "title": "Chapter 14 \u2013 Stepping into the Third Dimension",
+            "path": "Book_Object_Detection/Part_5_Advanced_Topics/Chapter_14_Stepping_into_the_Third_Dimension/Chapter_14.md"
+          },
+          {
+            "title": "Chapter 15 \u2013 The Future",
+            "path": "Book_Object_Detection/Part_5_Advanced_Topics/Chapter_15_The_Future/Chapter_15.md"
+          }
+        ]
+      },
+      {
+        "title": "Part 5: Advanced Topics and Future Directions",
+        "items": [
+          {
+            "title": "Chapter 14 \u2013 Stepping into the Third Dimension",
+            "path": "Book_Object_Detection/Part_5_Advanced_Topics_and_Future_Directions/Chapter_14_Stepping_into_the_Third_Dimension/Chapter_14.md"
+          },
+          {
+            "title": "Chapter 15 \u2013 The Future",
+            "path": "Book_Object_Detection/Part_5_Advanced_Topics_and_Future_Directions/Chapter_15_The_Future/Chapter_15.md"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Books | Obsidian Notes</title>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="stylesheet" href="assets/style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
+    <script src="assets/main.js" type="module" defer></script>
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="header-content">
+        <h1>Bookshelf</h1>
+        <p class="tagline">Explore the long-form research and book projects stored in this repository.</p>
+      </div>
+    </header>
+    <div class="layout">
+      <aside class="sidebar" id="sidebar" aria-label="Book navigation">
+        <div class="sidebar-inner">
+          <div class="sidebar-intro">
+            <h2>Library</h2>
+            <p>Select a chapter to load it on the right.</p>
+          </div>
+          <nav id="book-navigation" class="book-navigation" aria-live="polite"></nav>
+        </div>
+      </aside>
+      <main id="main" class="main-content" tabindex="-1">
+        <article id="book-content" class="book-content">
+          <div class="placeholder">
+            <p>Use the navigation to choose a chapter. The content will appear here.</p>
+          </div>
+        </article>
+      </main>
+    </div>
+    <footer class="page-footer">
+      <p>
+        Built with <a href="https://marked.js.org/" rel="noopener" target="_blank">Marked</a>. Markdown sources live in this repository,
+        so updates to the notes will automatically appear once the site is rebuilt.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/scripts/generate_books_index.py
+++ b/scripts/generate_books_index.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Generate navigation data for the book collection.
+
+The script scans every directory that starts with ``Book_`` and produces a JSON
+file (``books.json``) that contains metadata for the GitHub Pages site.  Each
+book includes the Markdown files that belong to it so that the front-end can
+load and render them on demand.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import List
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT = ROOT / "books.json"
+BOOK_PREFIX = "Book_"
+IGNORED_DIRECTORIES = {"images", "img", "assets", "static"}
+
+
+def natural_key(text: str) -> List[object]:
+    """Split text into digit and non-digit chunks for natural sorting."""
+    return [int(chunk) if chunk.isdigit() else chunk.lower() for chunk in re.split(r"(\d+)", text)]
+
+
+def natural_key_path(path: Path, base: Path) -> List[object]:
+    """Generate a natural sort key for a path relative to ``base``."""
+    parts: List[object] = []
+    for piece in path.relative_to(base).parts:
+        parts.extend(natural_key(piece))
+    return parts
+
+
+def format_book_title(folder_name: str) -> str:
+    """Return a human-friendly book title from the folder name."""
+    name = folder_name[len(BOOK_PREFIX) :] if folder_name.startswith(BOOK_PREFIX) else folder_name
+    name = name.replace("_", " ")
+    return name.strip()
+
+
+def format_section_title(name: str) -> str:
+    """Create a display title for a section directory."""
+    readable = name.replace("_", " ").strip()
+    match = re.match(r"^(Part\s+[\wIVXLC]+)(?:\s+)(.*)$", readable)
+    if match:
+        prefix, remainder = match.groups()
+        return f"{prefix}: {remainder}" if remainder else prefix
+    return readable
+
+
+def insert_spaces_from_camel_case(text: str) -> str:
+    """Insert spaces between camelCase or PascalCase boundaries."""
+    return re.sub(r"(?<=[a-z0-9])([A-Z])", r" \1", text)
+
+
+def format_item_title(source: str) -> str:
+    """Convert a file stem into a readable title."""
+    readable = source.replace("_", " ").strip()
+    if "_" not in source and re.search(r"[a-z][A-Z]", source):
+        readable = insert_spaces_from_camel_case(source)
+    match = re.match(r"^(Chapter\s+[\wIVXLC]+)(?:\s+)(.*)$", readable)
+    if match:
+        prefix, remainder = match.groups()
+        if remainder:
+            return f"{prefix} – {remainder}"
+        return prefix
+    normalised = readable.replace(" ", "").lower()
+    if normalised == "tableofcontents":
+        return "Table of Contents"
+    return readable
+
+
+def discover_markdown_files(directory: Path) -> List[Path]:
+    """Return all Markdown files under ``directory`` ignoring auxiliary folders."""
+    markdown_files = []
+    for path in directory.rglob("*.md"):
+        if any(part in IGNORED_DIRECTORIES for part in path.parts):
+            continue
+        markdown_files.append(path)
+    return markdown_files
+
+
+def build_book(book_dir: Path) -> dict:
+    """Build the data structure describing a single book."""
+    sections = []
+
+    overview_files = sorted(book_dir.glob("*.md"), key=lambda p: natural_key(p.stem))
+    if overview_files:
+        sections.append(
+            {
+                "title": "Overview",
+                "items": [make_item(file_path) for file_path in overview_files],
+            }
+        )
+
+    part_dirs = [
+        child
+        for child in book_dir.iterdir()
+        if child.is_dir() and not child.name.startswith(".") and child.name not in IGNORED_DIRECTORIES
+    ]
+
+    for part_dir in sorted(part_dirs, key=lambda p: natural_key(p.name)):
+        markdown_files = discover_markdown_files(part_dir)
+        if not markdown_files:
+            continue
+        sections.append(
+            {
+                "title": format_section_title(part_dir.name),
+                "items": [
+                    make_item(md_file, display_root=part_dir)
+                    for md_file in sorted(markdown_files, key=lambda p: natural_key_path(p, part_dir))
+                ],
+            }
+        )
+
+    return {
+        "title": format_book_title(book_dir.name),
+        "path": book_dir.name,
+        "sections": sections,
+    }
+
+
+def make_item(path: Path, display_root: Path | None = None) -> dict:
+    """Create the JSON representation for a markdown file."""
+    stem = path.stem
+    if stem.lower() == "readme":
+        stem = display_root.name if display_root is not None else path.parent.name
+
+    parent_name = path.parent.name
+    if display_root is not None and path.parent != display_root:
+        stem = parent_name
+    elif re.match(r"Chapter[_-]", stem, re.IGNORECASE) and parent_name.lower().startswith(stem.lower()):
+        stem = parent_name
+
+    return {
+        "title": format_item_title(stem),
+        "path": path.relative_to(ROOT).as_posix(),
+    }
+
+
+def main() -> None:
+    book_dirs = [p for p in ROOT.iterdir() if p.is_dir() and p.name.startswith(BOOK_PREFIX)]
+    books = [build_book(book_dir) for book_dir in sorted(book_dirs, key=lambda p: natural_key(p.name))]
+
+    OUTPUT.write_text(json.dumps(books, indent=2), encoding="utf-8")
+    print(f"Wrote {OUTPUT.relative_to(ROOT)} with {len(books)} books.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a static GitHub Pages bookshelf with navigation and chapter rendering
- generate books.json via a helper script to keep navigation metadata in sync
- document the publishing workflow and local preview instructions

## Testing
- python3 scripts/generate_books_index.py
- python3 -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68cbb64824a083218ad9d8ca5ffd5263