### PR TITLE
Configure site to use Jekyll theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,6 @@
+title: Obsidian Notes – Bookshelf
+description: Explore the long-form research and book projects stored in this repository.
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+  - jekyll-feed
+  - jekyll-seo-tag

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,4 @@
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+<link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
+<script src="{{ '/assets/main.js' | relative_url }}" type="module" defer></script>

--- a/assets/main.js
+++ b/assets/main.js
@@ -55,7 +55,7 @@ function buildNavigation(books) {
 
   books.forEach((book, bookIndex) => {
     const bookContainer = document.createElement("div");
-    bookContainer.className = "book";
+    bookContainer.className = "bookshelf-book";
 
     const bookHeader = document.createElement("h3");
     bookHeader.textContent = book.title;
@@ -63,7 +63,7 @@ function buildNavigation(books) {
 
     book.sections.forEach((section, sectionIndex) => {
       const details = document.createElement("details");
-      details.className = "section";
+      details.className = "bookshelf-section";
       if (bookIndex === 0 && sectionIndex === 0) {
         details.open = true;
       }
@@ -183,19 +183,19 @@ function stripFrontMatter(markdown) {
 }
 
 function renderLoading() {
-  contentEl.innerHTML = '<div class="status-message">Loading chapter…</div>';
+  contentEl.innerHTML = '<div class="bookshelf-status">Loading chapter…</div>';
 }
 
 function renderError(message) {
-  contentEl.innerHTML = `<div class="status-message error"><strong>Something went wrong.</strong><br>${message}</div>`;
+  contentEl.innerHTML = `<div class="bookshelf-status error"><strong>Something went wrong.</strong><br>${message}</div>`;
 }
 
 function renderNavigationPlaceholder(message) {
-  navigationEl.innerHTML = `<div class="status-message error">${message}</div>`;
+  navigationEl.innerHTML = `<div class="bookshelf-status error">${message}</div>`;
 }
 
 function renderContentMessage(message) {
-  contentEl.innerHTML = `<div class="status-message">${message}</div>`;
+  contentEl.innerHTML = `<div class="bookshelf-status">${message}</div>`;
 }
 
 function firstChapterPath(books) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -15,8 +15,14 @@
   box-sizing: border-box;
 }
 
-body {
-  margin: 0;
+main#content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0;
+  width: 100%;
+}
+
+.bookshelf-page {
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
@@ -24,30 +30,30 @@ body {
   flex-direction: column;
 }
 
-.page-header {
+.bookshelf-header {
   background: var(--bg-alt);
   border-bottom: 1px solid var(--border);
   padding: 2rem 3rem 1.5rem;
   box-shadow: var(--shadow);
 }
 
-.header-content {
+.bookshelf-header__content {
   max-width: 960px;
   margin: 0 auto;
 }
 
-.page-header h1 {
+.bookshelf-header h1 {
   margin: 0;
   font-size: 2.5rem;
 }
 
-.tagline {
+.bookshelf-header__tagline {
   margin: 0.5rem 0 0;
   color: var(--text-muted);
   font-size: 1.05rem;
 }
 
-.layout {
+.bookshelf-layout {
   flex: 1;
   display: grid;
   grid-template-columns: minmax(260px, 320px) 1fr;
@@ -59,13 +65,13 @@ body {
   box-sizing: border-box;
 }
 
-.sidebar {
+.bookshelf-sidebar {
   position: sticky;
   top: 1.5rem;
   align-self: start;
 }
 
-.sidebar-inner {
+.bookshelf-sidebar__inner {
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: 16px;
@@ -75,68 +81,68 @@ body {
   overflow: auto;
 }
 
-.sidebar-intro h2 {
+.bookshelf-sidebar__intro h2 {
   margin: 0;
   font-size: 1.35rem;
 }
 
-.sidebar-intro p {
+.bookshelf-sidebar__intro p {
   margin: 0.5rem 0 1.25rem;
   color: var(--text-muted);
   font-size: 0.95rem;
 }
 
-.book-navigation {
+.bookshelf-navigation {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.book {
+.bookshelf-book {
   border-top: 1px solid var(--border);
   padding-top: 1rem;
 }
 
-.book:first-child {
+.bookshelf-book:first-child {
   border-top: none;
   padding-top: 0;
 }
 
-.book > h3 {
+.bookshelf-book > h3 {
   margin: 0;
   font-size: 1.2rem;
 }
 
-.section {
+.bookshelf-section {
   margin-top: 0.75rem;
 }
 
-.section summary {
+.bookshelf-section summary {
   cursor: pointer;
   font-weight: 600;
   color: var(--text-muted);
   list-style: none;
 }
 
-.section summary::marker {
+.bookshelf-section summary::marker {
   display: none;
 }
 
-.section summary::-webkit-details-marker {
+.bookshelf-section summary::-webkit-details-marker {
   display: none;
 }
 
-.section summary::after {
+.bookshelf-section summary::after {
   content: "▾";
   float: right;
   transition: transform 0.2s ease;
 }
 
-.section[open] summary::after {
+.bookshelf-section[open] summary::after {
   transform: rotate(-180deg);
 }
 
-.section ul {
+.bookshelf-section ul {
   list-style: none;
   margin: 0.5rem 0 0;
   padding: 0;
@@ -145,7 +151,7 @@ body {
   gap: 0.35rem;
 }
 
-.section a {
+.bookshelf-section a {
   display: block;
   text-decoration: none;
   color: var(--text);
@@ -155,23 +161,23 @@ body {
   transition: background 0.15s ease, color 0.15s ease;
 }
 
-.section a:hover,
-.section a:focus {
+.bookshelf-section a:hover,
+.bookshelf-section a:focus {
   background: var(--accent-soft);
   color: var(--accent);
   outline: none;
 }
 
-.section a.active {
+.bookshelf-section a.active {
   background: var(--accent);
   color: #fff;
 }
 
-.main-content {
+.bookshelf-main {
   padding-left: 2rem;
 }
 
-.book-content {
+.bookshelf-content {
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: 20px;
@@ -181,36 +187,36 @@ body {
   overflow: hidden;
 }
 
-.book-content h1,
-.book-content h2,
-.book-content h3 {
+.bookshelf-content h1,
+.bookshelf-content h2,
+.bookshelf-content h3 {
   color: var(--text);
 }
 
-.book-content h1 {
+.bookshelf-content h1 {
   font-size: 2rem;
 }
 
-.book-content h2 {
+.bookshelf-content h2 {
   font-size: 1.5rem;
 }
 
-.book-content h3 {
+.bookshelf-content h3 {
   font-size: 1.25rem;
 }
 
-.book-content p {
+.bookshelf-content p {
   line-height: 1.7;
   margin: 1rem 0;
   color: var(--text);
 }
 
-.book-content ul,
-.book-content ol {
+.bookshelf-content ul,
+.bookshelf-content ol {
   padding-left: 1.25rem;
 }
 
-.book-content pre {
+.bookshelf-content pre {
   background: #0f172a;
   color: #f8fafc;
   padding: 1rem;
@@ -218,7 +224,7 @@ body {
   overflow: auto;
 }
 
-.book-content code {
+.bookshelf-content code {
   background: rgba(15, 23, 42, 0.07);
   padding: 0.2rem 0.35rem;
   border-radius: 6px;
@@ -226,25 +232,25 @@ body {
   font-size: 0.9rem;
 }
 
-.placeholder {
+.bookshelf-placeholder {
   text-align: center;
   color: var(--text-muted);
   padding: 3rem 1rem;
 }
 
-.status-message {
+.bookshelf-status {
   background: rgba(15, 23, 42, 0.05);
   border-radius: 12px;
   padding: 1rem;
   margin-bottom: 1.5rem;
 }
 
-.status-message.error {
+.bookshelf-status.error {
   background: rgba(220, 38, 38, 0.1);
   color: #991b1b;
 }
 
-.page-footer {
+.bookshelf-footer {
   background: var(--bg-alt);
   border-top: 1px solid var(--border);
   padding: 1.5rem 3rem;
@@ -253,25 +259,25 @@ body {
   font-size: 0.9rem;
 }
 
-.page-footer a {
+.bookshelf-footer a {
   color: var(--accent);
 }
 
 @media (max-width: 960px) {
-  .layout {
+  .bookshelf-layout {
     grid-template-columns: 1fr;
     padding: 1rem;
   }
 
-  .sidebar {
+  .bookshelf-sidebar {
     position: static;
   }
 
-  .sidebar-inner {
+  .bookshelf-sidebar__inner {
     max-height: none;
   }
 
-  .main-content {
+  .bookshelf-main {
     padding: 1.5rem 0 0;
   }
 }
@@ -288,12 +294,12 @@ body {
     --shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
   }
 
-  .book-content pre {
+  .bookshelf-content pre {
     background: #1e293b;
     color: #f8fafc;
   }
 
-  .book-content code {
+  .bookshelf-content code {
     background: rgba(148, 163, 184, 0.12);
   }
 }

--- a/index.html
+++ b/index.html
@@ -1,44 +1,44 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Books | Obsidian Notes</title>
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-    <link rel="stylesheet" href="assets/style.css" />
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
-    <script src="assets/main.js" type="module" defer></script>
-  </head>
-  <body>
-    <header class="page-header">
-      <div class="header-content">
-        <h1>Bookshelf</h1>
-        <p class="tagline">Explore the long-form research and book projects stored in this repository.</p>
-      </div>
-    </header>
-    <div class="layout">
-      <aside class="sidebar" id="sidebar" aria-label="Book navigation">
-        <div class="sidebar-inner">
-          <div class="sidebar-intro">
-            <h2>Library</h2>
-            <p>Select a chapter to load it on the right.</p>
-          </div>
-          <nav id="book-navigation" class="book-navigation" aria-live="polite"></nav>
-        </div>
-      </aside>
-      <main id="main" class="main-content" tabindex="-1">
-        <article id="book-content" class="book-content">
-          <div class="placeholder">
-            <p>Use the navigation to choose a chapter. The content will appear here.</p>
-          </div>
-        </article>
-      </main>
-    </div>
-    <footer class="page-footer">
-      <p>
-        Built with <a href="https://marked.js.org/" rel="noopener" target="_blank">Marked</a>. Markdown sources live in this repository,
-        so updates to the notes will automatically appear once the site is rebuilt.
+---
+layout: default
+permalink: /
+title: Books | Obsidian Notes
+description: Explore the long-form research and book projects stored in this repository.
+---
+
+<div class="bookshelf-page">
+  <header class="bookshelf-header">
+    <div class="bookshelf-header__content">
+      <h1>Bookshelf</h1>
+      <p class="bookshelf-header__tagline">
+        Explore the long-form research and book projects stored in this repository.
       </p>
-    </footer>
-  </body>
-</html>
+    </div>
+  </header>
+
+  <div class="bookshelf-layout">
+    <aside class="bookshelf-sidebar" id="sidebar" aria-label="Book navigation">
+      <div class="bookshelf-sidebar__inner">
+        <div class="bookshelf-sidebar__intro">
+          <h2>Library</h2>
+          <p>Select a chapter to load it on the right.</p>
+        </div>
+        <nav id="book-navigation" class="bookshelf-navigation" aria-live="polite"></nav>
+      </div>
+    </aside>
+
+    <main id="main" class="bookshelf-main" tabindex="-1">
+      <article id="book-content" class="bookshelf-content">
+        <div class="bookshelf-placeholder">
+          <p>Use the navigation to choose a chapter. The content will appear here.</p>
+        </div>
+      </article>
+    </main>
+  </div>
+
+  <footer class="bookshelf-footer">
+    <p>
+      Built with <a href="https://marked.js.org/" rel="noopener" target="_blank">Marked</a>. Markdown sources live in this repository,
+      so updates to the notes will automatically appear once the site is rebuilt.
+    </p>
+  </footer>
+</div>


### PR DESCRIPTION
## Summary
- enable the Cayman GitHub Pages theme for the site and add metadata
- refactor the homepage markup to work with the themed layout while preserving functionality
- scope styles and scripts to the new structure so the bookshelf UI renders correctly

## Testing
- not run (static site changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cbbf2806fc8321840a03905caf15e2