### PR TITLE
Add GitHub Pages link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Obsidian Notes – Bookshelf
 
-This repository contains long-form research notes and two in-progress books:
+This repository contains long-form research notes and two in-progress books.
+
+👉 View the published site on GitHub Pages: <https://atulsingh-nikki.github.io/obsidian-notes/>
+
+The collection currently features:
 
 - **Color Correction**
 - **Object Detection**


### PR DESCRIPTION
## Summary
- add a direct link to the published GitHub Pages site in the README
- clarify the introduction text before the list of available books

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68cc2083df8483218fba59041f8c3620