### PR TITLE
Add blog navigation bar, hide GitHub banner, and enable MathJax

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,15 @@
 title: Obsidian Notes – Bookshelf
 description: Explore the long-form research and book projects stored in this repository.
+markdown: kramdown
+kramdown:
+  input: GFM
+  math_engine: mathjax
+  math_engine_opts:
+    preview: false
 remote_theme: pages-themes/cayman@v0.2.0
 repository: atulsingh-nikki/obsidian-notes
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+github:
+  is_project_page: false

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,4 +1,18 @@
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
+<script>
+  window.MathJax = {
+    tex: {
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']],
+      processEscapes: true
+    },
+    options: {
+      skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+      ignoreHtmlClass: 'tex2jax_ignore'
+    }
+  };
+</script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
 <script src="{{ '/assets/main.js' | relative_url }}" type="module" defer></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,16 +20,32 @@ layout: default
     {{ content }}
   </div>
 
-  <nav class="blog-post__nav" aria-label="Blog post">
-    {%- if page.previous -%}
-      <a class="blog-post__nav-link blog-post__nav-link--prev" href="{{ page.previous.url | relative_url }}">
-        ← {{ page.previous.title }}
-      </a>
-    {%- endif -%}
-    {%- if page.next -%}
-      <a class="blog-post__nav-link blog-post__nav-link--next" href="{{ page.next.url | relative_url }}">
-        {{ page.next.title }} →
-      </a>
-    {%- endif -%}
+  <nav class="blog-post__nav" aria-label="Post navigation">
+    <ul class="blog-post__nav-list">
+      <li class="blog-post__nav-item">
+        <a class="blog-post__nav-link blog-post__nav-link--home" href="{{ '/' | relative_url }}">
+          ← Home
+        </a>
+      </li>
+      <li class="blog-post__nav-item">
+        <a class="blog-post__nav-link blog-post__nav-link--index" href="{{ '/blog/' | relative_url }}">
+          Blog index
+        </a>
+      </li>
+      {%- if page.previous -%}
+        <li class="blog-post__nav-item">
+          <a class="blog-post__nav-link blog-post__nav-link--prev" href="{{ page.previous.url | relative_url }}">
+            ← Previous: {{ page.previous.title }}
+          </a>
+        </li>
+      {%- endif -%}
+      {%- if page.next -%}
+        <li class="blog-post__nav-item">
+          <a class="blog-post__nav-link blog-post__nav-link--next" href="{{ page.next.url | relative_url }}">
+            Next: {{ page.next.title }} →
+          </a>
+        </li>
+      {%- endif -%}
+    </ul>
   </nav>
 </article>

--- a/assets/style.css
+++ b/assets/style.css
@@ -391,16 +391,36 @@ main#content {
 
 .blog-post__nav {
   margin-top: 3rem;
+  border-top: 1px solid var(--border);
+  padding-top: 1.5rem;
+}
+
+.blog-post__nav-list {
+  list-style: none;
   display: flex;
-  justify-content: space-between;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+}
+
+.blog-post__nav-item {
+  flex: 1 1 240px;
+  min-width: 200px;
 }
 
 .blog-post__nav-link {
+  display: block;
+  width: 100%;
   color: var(--accent);
   text-decoration: none;
   font-weight: 600;
-  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--bg-alt);
+  text-align: center;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .blog-post__nav-link--prev {
@@ -413,7 +433,11 @@ main#content {
 
 .blog-post__nav-link:hover,
 .blog-post__nav-link:focus {
-  text-decoration: underline;
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.18);
+  outline: none;
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- add home and blog index links to post layout navigation so readers can move between entries more easily
- restyle the blog navigation bar for the new layout
- disable the Cayman theme "View on GitHub" banner on the home page
- enable MathJax so that LaTeX equations on blog posts render correctly

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68cc2fdc15b08321bdef9b4cb3f919fd