### PR TITLE
Fix image paths in illuminants blog post

### DIFF
--- a/_posts/2025-09-22-how-cameras-and-eyes-ses-light-from-spectra-to-illuminants.md
+++ b/_posts/2025-09-22-how-cameras-and-eyes-ses-light-from-spectra-to-illuminants.md
@@ -16,7 +16,7 @@ Every light source has its own **spectral power distribution (SPD)**: how much e
 
 **Units:** watts per nanometer (W/nm), telling you how much power is packed into each tiny slice of the spectrum.  
 
-![Spectral Power Distributions of different light sources](images/spd_placeholder.png)
+![Spectral Power Distributions of different light sources]({{ "/assets/images/spd_placeholder.png" | relative_url }})
 
 ---
 
@@ -31,7 +31,7 @@ $$
 - Red apple → high in red, low elsewhere.  
 - Asphalt → very low everywhere.  
 
-![Surface reflectance spectra for different materials](images/reflectance_placeholder.png)
+![Surface reflectance spectra for different materials]({{ "/assets/images/reflectance_placeholder.png" | relative_url }})
 
 ---
 
@@ -44,7 +44,7 @@ $$
 E_c = \int L(\lambda)\,R(\lambda)\,S_c(\lambda)\,d\lambda
 $$  
 
-![Camera spectral sensitivity curves for RGB channels](images/camera_sensitivity_placeholder.png)
+![Camera spectral sensitivity curves for RGB channels]({{ "/assets/images/camera_sensitivity_placeholder.png" | relative_url }})
 
 ---
 
@@ -57,7 +57,7 @@ Each stage scales the signal:
 
 At each wavelength, multiply them. Then integrate over all wavelengths.  
 
-![Per-channel contribution: L(λ) × R(λ) × S_c(λ)](images/multiplication_chain_placeholder.png)
+![Per-channel contribution: L(λ) × R(λ) × S_c(λ)]({{ "/assets/images/multiplication_chain_placeholder.png" | relative_url }})
 
 ---
 
@@ -66,7 +66,7 @@ The human eye samples color with **three cone types** (S, M, L). Each has its ow
 
 A camera with a Bayer filter does something similar but clumsier: each pixel sees only one filter (R, G, or B), so it needs **debayering** (interpolating missing channels) to reconstruct full RGB.  
 
-![Human cone sensitivity vs camera Bayer filter comparison](images/cones_vs_bayer_placeholder.png)
+![Human cone sensitivity vs camera Bayer filter comparison]({{ "/assets/images/cones_vs_bayer_placeholder.png" | relative_url }})
 
 ---
 
@@ -88,7 +88,7 @@ Classic trick: assume that, on average, the world is gray.
 - If the averages aren’t equal, the imbalance is blamed on the illuminant.  
 - Correct by scaling channels to equalize the averages.  
 
-![Gray World assumption: channel means before and after correction](images/grayworld_placeholder.png)
+![Gray World assumption: channel means before and after correction]({{ "/assets/images/grayworld_placeholder.png" | relative_url }})
 
 ---
 
@@ -103,7 +103,7 @@ E_c^{(p)} = \left(\frac{1}{N} \sum_i I_c(i)^p \right)^{1/p}
 - \(p=\infty\): White Patch (brightest pixel).  
 - Intermediate \(p\): Shades of Gray methods.  
 
-![Minkowski p-norm: varying emphasis from mean (p=1) to max (p→∞)](images/minkowski_placeholder.png)
+![Minkowski p-norm: varying emphasis from mean (p=1) to max (p→∞)]({{ "/assets/images/minkowski_placeholder.png" | relative_url }})
 
 ---
 
@@ -126,7 +126,7 @@ Computer vision strategies:
 - Train deep models to output illuminant fields.  
 - Sometimes, ask the user (click the white patch in software).  
 
-![Multiple illuminants: example spectral power distributions and mixed lighting](images/multiple_lights_placeholder.png)
+![Multiple illuminants: example spectral power distributions and mixed lighting]({{ "/assets/images/multiple_lights_placeholder.png" | relative_url }})
 
 ---
 
@@ -178,7 +178,7 @@ Humans are incredibly good at using **spatial relationships**:
 ### The Remarkable Result
 Put it all together, and humans achieve something cameras still struggle with: **seeing object color, not illuminant color**. We literally see past the physics to perceive the underlying material properties.
 
-![Human color constancy: how context affects perceived color](images/human_constancy_placeholder.png)
+![Human color constancy: how context affects perceived color]({{ "/assets/images/human_constancy_placeholder.png" | relative_url }})
 
 ### What Makes This Image Special
 


### PR DESCRIPTION
## Summary
- update all image references in the illuminants blog post to use the Jekyll `relative_url` filter so they load from `/assets/images`

## Testing
- bundle exec jekyll build *(fails with existing YAML warnings from unrelated research notes but site still builds)*

------
https://chatgpt.com/codex/tasks/task_e_68d15750b03883218847da048b369330