### PR TITLE
Display books and blog columns side by side on homepage

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -45,12 +45,176 @@ body .main-content {
   }
 }
 
-.bookshelf-page {
+.home-page {
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
+  padding: 2.5rem 2rem;
+}
+
+.home-page__grid {
+  max-width: 95%;
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+}
+
+.home-page__column {
   display: flex;
   flex-direction: column;
+}
+
+.home-page__column--books,
+.home-page__column--blog {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+  min-height: 100%;
+}
+
+.home-page__column--books {
+  overflow: hidden;
+}
+
+.home-page__column--books .bookshelf-header,
+.home-page__column--books .bookshelf-footer {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 2rem 2.5rem 1.5rem;
+}
+
+.home-page__column--books .bookshelf-footer {
+  padding: 1.5rem 2.5rem 2.25rem;
+  text-align: left;
+  color: var(--text-muted);
+}
+
+.home-page__column--books .bookshelf-header__content {
+  max-width: 100%;
+  margin: 0;
+}
+
+.home-page__column--books .bookshelf-layout {
+  flex: 1;
+  max-width: none;
+  margin: 0;
+  width: 100%;
+  padding: 0 2.5rem 2.5rem;
+}
+
+.home-page__column--books .bookshelf-content {
+  min-height: 420px;
+}
+
+.home-page__column--blog {
+  padding: 2.5rem;
+  gap: 2rem;
+}
+
+.home-blog__header h2 {
+  margin: 0;
+  font-size: 2.1rem;
+}
+
+.home-blog__description {
+  margin: 0.75rem 0 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.home-blog__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.home-blog__item {
+  padding-bottom: 1.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.home-blog__item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.home-blog__item-title {
+  margin: 0;
+  font-size: 1.55rem;
+}
+
+.home-blog__item-title a {
+  text-decoration: none;
+  color: var(--text);
+}
+
+.home-blog__item-title a:hover,
+.home-blog__item-title a:focus {
+  color: var(--accent);
+}
+
+.home-blog__item-meta {
+  margin: 0.45rem 0 0.9rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.home-blog__item-excerpt {
+  margin: 0 0 1.1rem;
+  color: var(--text);
+  line-height: 1.7;
+}
+
+.home-blog__item-read-more {
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--accent);
+}
+
+.home-blog__item-read-more:hover,
+.home-blog__item-read-more:focus {
+  text-decoration: underline;
+}
+
+.home-blog__empty {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.home-blog__cta {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: var(--accent);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.18);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.home-blog__cta:hover,
+.home-blog__cta:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px rgba(79, 70, 229, 0.22);
+  background: #4338ca;
+}
+
+.home-blog__cta:focus-visible {
+  outline: 3px solid rgba(79, 70, 229, 0.35);
+  outline-offset: 4px;
+}
+
+@media (min-width: 64em) {
+  .home-page__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: stretch;
+  }
 }
 
 .bookshelf-header {
@@ -483,6 +647,44 @@ article .blog-post__content {
 }
 
 @media (max-width: 960px) {
+  .home-page {
+    padding: 2rem 1.25rem;
+  }
+
+  .home-page__column--books,
+  .home-page__column--blog {
+    border-radius: 20px;
+  }
+
+  .home-page__column--books .bookshelf-header,
+  .home-page__column--books .bookshelf-footer {
+    padding: 1.75rem 1.75rem 1.25rem;
+  }
+
+  .home-page__column--books .bookshelf-footer {
+    padding-bottom: 1.75rem;
+  }
+
+  .home-page__column--books .bookshelf-layout {
+    padding: 0 1.75rem 1.75rem;
+  }
+
+  .home-page__column--books .bookshelf-content {
+    min-height: 360px;
+  }
+
+  .home-page__column--blog {
+    padding: 2rem 1.75rem;
+  }
+
+  .home-blog__header h2 {
+    font-size: 1.9rem;
+  }
+
+  .home-blog__item-title {
+    font-size: 1.4rem;
+  }
+
   .bookshelf-layout {
     grid-template-columns: 1fr;
     padding: 1rem;
@@ -584,6 +786,48 @@ article .blog-post__content {
 
 /* Better mobile table handling */
 @media (max-width: 768px) {
+  .home-page {
+    padding: 1.75rem 1rem;
+  }
+
+  .home-page__grid {
+    gap: 1.5rem;
+  }
+
+  .home-page__column--books .bookshelf-header,
+  .home-page__column--books .bookshelf-footer {
+    padding: 1.5rem 1.5rem 1.15rem;
+  }
+
+  .home-page__column--books .bookshelf-footer {
+    padding-bottom: 1.5rem;
+  }
+
+  .home-page__column--books .bookshelf-layout {
+    padding: 0 1.25rem 1.5rem;
+  }
+
+  .home-page__column--books .bookshelf-content {
+    min-height: 320px;
+  }
+
+  .home-page__column--blog {
+    padding: 1.75rem 1.25rem;
+  }
+
+  .home-blog__item {
+    padding-bottom: 1.5rem;
+  }
+
+  .home-blog__item-title {
+    font-size: 1.3rem;
+  }
+
+  .home-blog__cta {
+    width: 100%;
+    justify-content: center;
+  }
+
   .blog-post__content table {
     font-size: 0.85rem;
     margin: 1.5rem 0;

--- a/index.html
+++ b/index.html
@@ -5,43 +5,80 @@ title: Atul Singh Notes
 description: Explore the long-form research and learning projects stored in this repository.
 ---
 
-<div class="bookshelf-page">
-  <header class="bookshelf-header">
-    <div class="bookshelf-header__content">
-      <h1>Learning Collection</h1>
-      <p class="bookshelf-header__tagline">
-        Explore the long-form research and learning projects stored in this repository.
-      </p>
-      <p class="bookshelf-header__blog-cta">
-        Looking for shorter updates? Visit the <a href="{{ '/blog/' | relative_url }}">blog</a> for essays and changelog-style notes.
-      </p>
-    </div>
-  </header>
-
-  <div class="bookshelf-layout">
-    <aside class="bookshelf-sidebar" id="sidebar" aria-label="Book navigation">
-      <div class="bookshelf-sidebar__inner">
-        <div class="bookshelf-sidebar__intro">
-          <h2>Contents</h2>
-          <p>Select a chapter to load it on the right.</p>
+<div class="home-page">
+  <div class="home-page__grid">
+    <section class="home-page__column home-page__column--books" aria-labelledby="learning-collection">
+      <header class="bookshelf-header">
+        <div class="bookshelf-header__content">
+          <h1 id="learning-collection">Learning Collection</h1>
+          <p class="bookshelf-header__tagline">
+            Explore the long-form research and learning projects stored in this repository.
+          </p>
+          <p class="bookshelf-header__blog-cta">
+            Looking for shorter updates? Visit the <a href="{{ '/blog/' | relative_url }}">blog</a> for essays and changelog-style notes.
+          </p>
         </div>
-        <nav id="book-navigation" class="bookshelf-navigation" aria-live="polite"></nav>
+      </header>
+
+      <div class="bookshelf-layout">
+        <aside class="bookshelf-sidebar" id="sidebar" aria-label="Book navigation">
+          <div class="bookshelf-sidebar__inner">
+            <div class="bookshelf-sidebar__intro">
+              <h2>Contents</h2>
+              <p>Select a chapter to load it on the right.</p>
+            </div>
+            <nav id="book-navigation" class="bookshelf-navigation" aria-live="polite"></nav>
+          </div>
+        </aside>
+
+        <main id="main" class="bookshelf-main" tabindex="-1">
+          <article id="book-content" class="bookshelf-content">
+            <div class="bookshelf-placeholder">
+              <p>Use the navigation to choose a chapter. The content will appear here.</p>
+            </div>
+          </article>
+        </main>
       </div>
-    </aside>
 
-    <main id="main" class="bookshelf-main" tabindex="-1">
-      <article id="book-content" class="bookshelf-content">
-        <div class="bookshelf-placeholder">
-          <p>Use the navigation to choose a chapter. The content will appear here.</p>
+      <footer class="bookshelf-footer">
+        <p>
+          Built with <a href="https://marked.js.org/" rel="noopener" target="_blank">Marked</a>. Markdown sources live in this repository,
+          so updates to the notes will automatically appear once the site is rebuilt.
+        </p>
+      </footer>
+    </section>
+
+    <section class="home-page__column home-page__column--blog" aria-labelledby="homepage-blog">
+      <header class="home-blog__header">
+        <h2 id="homepage-blog">Latest from the Blog</h2>
+        <p class="home-blog__description">
+          Short updates, context, and essays that complement the long-form notes in the bookshelf.
+        </p>
+      </header>
+
+      {%- if site.posts and site.posts.size > 0 -%}
+        <div class="home-blog__list">
+          {%- for post in site.posts limit: 4 -%}
+            <article class="home-blog__item">
+              <h3 class="home-blog__item-title">
+                <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+              </h3>
+              <p class="home-blog__item-meta">
+                <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+                {%- if post.tags and post.tags.size > 0 -%}
+                  · <span class="home-blog__item-tags">{{ post.tags | join: ", " }}</span>
+                {%- endif -%}
+              </p>
+              <p class="home-blog__item-excerpt">{{ post.excerpt | strip_html | truncate: 180 }}</p>
+              <a class="home-blog__item-read-more" href="{{ post.url | relative_url }}">Read more →</a>
+            </article>
+          {%- endfor -%}
         </div>
-      </article>
-    </main>
-  </div>
+      {%- else -%}
+        <p class="home-blog__empty">No posts yet. Check back soon for updates.</p>
+      {%- endif -%}
 
-  <footer class="bookshelf-footer">
-    <p>
-      Built with <a href="https://marked.js.org/" rel="noopener" target="_blank">Marked</a>. Markdown sources live in this repository,
-      so updates to the notes will automatically appear once the site is rebuilt.
-    </p>
-  </footer>
+      <a class="home-blog__cta" href="{{ '/blog/' | relative_url }}">Explore all posts →</a>
+    </section>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- restructure the homepage into a two-column layout so the bookshelf and latest blog posts share the hero view
- add responsive styles for the new home grid, blog summaries, and adjusted bookshelf panel presentation

## Testing
- bundle exec jekyll build *(warns about existing YAML front matter in Research drafts)*

------
https://chatgpt.com/codex/tasks/task_e_68d21a457bcc8321a1450faa0c8cf67f