### PR TITLE
Configure analytics measurement ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,7 @@ plugins:
   - jekyll-seo-tag
 github:
   is_project_page: false
+
+# Configure Google Analytics by setting a measurement ID.
+# Update this value to change the property that receives traffic metrics.
+google_analytics: G-3X6LQQ24YV

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,6 +1,17 @@
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
 
+{% if jekyll.environment == "production" and site.google_analytics %}
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics | escape }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '{{ site.google_analytics | escape }}');
+  </script>
+{% endif %}
+
 <!-- MathJax Configuration -->
 <script>
   window.MathJax = {


### PR DESCRIPTION
## Summary
- set the Google Analytics measurement ID in site configuration
- align the production Analytics snippet with the standard gtag template

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d23fea14b88321920afd569f8b08ae