### PR TITLE
Add primary navigation bar to the home page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -52,6 +52,64 @@ body .main-content {
   padding: 2.5rem 2rem;
 }
 
+.home-page__nav {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  margin: 0 auto 2rem;
+  max-width: 95%;
+}
+
+.home-page__nav-inner {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem 1.5rem;
+  justify-content: space-between;
+  padding: 1rem 1.75rem;
+}
+
+.home-page__brand {
+  color: var(--text);
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+}
+
+.home-page__brand:hover,
+.home-page__brand:focus {
+  color: var(--accent);
+}
+
+.home-page__nav-links {
+  display: flex;
+  gap: 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.home-page__nav-links li {
+  margin: 0;
+}
+
+.home-page__nav-links a {
+  color: var(--text);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.home-page__nav-links a:hover,
+.home-page__nav-links a:focus {
+  color: var(--accent);
+}
+
+#learning-collection {
+  scroll-margin-top: 6rem;
+}
+
 .home-page__grid {
   max-width: 95%;
   margin: 0 auto;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@ description: Explore the long-form research and learning projects stored in this
 ---
 
 <div class="home-page">
+  <nav class="home-page__nav" aria-label="Primary">
+    <div class="home-page__nav-inner">
+      <a class="home-page__brand" href="{{ '/' | relative_url }}">Atul Singh Notes</a>
+      <ul class="home-page__nav-links">
+        <li><a href="#learning-collection">Learning Collection</a></li>
+        <li><a href="{{ '/blog/' | relative_url }}">Blog</a></li>
+      </ul>
+    </div>
+  </nav>
   <div class="home-page__grid">
     <section class="home-page__column home-page__column--books" aria-labelledby="learning-collection">
       <header class="bookshelf-header">


### PR DESCRIPTION
## Summary
- add a top-level navigation bar to the home page with quick links to the learning collection and blog
- style the navigation bar to match the existing design and ensure anchored content scrolls correctly

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68da94d8e3508321813b311b4d72d2c0