### PR TITLE
Clarify closed-form definition and integral example

### DIFF
--- a/_posts/2025-03-05-random-vs-stochastic-foundations.md
+++ b/_posts/2025-03-05-random-vs-stochastic-foundations.md
@@ -54,7 +54,11 @@ If your interest is the distribution of isolated measurements, call the object r
 
 ## Sampling: From Random Draws to Stochastic Simulation
 
-Sampling is the connective tissue between abstract probability models and the finite data we can actually observe or compute. Even when a distribution is fully specified, we often cannot write closed-form expressions for expectations, gradients, or risk functionals. Sampling supplies approximations by turning integrals into averages, letting us stress-test models, calibrate parameters, and propagate uncertainty through downstream decisions. The more structure we impose (e.g., temporal dependence or spatial correlation), the more carefully our sampling strategies must mirror that structure.
+Sampling is the connective tissue between abstract probability models and the finite data we can actually observe or compute. Even when a distribution is fully specified, we often cannot write closed-form expressions for expectations, gradients, or risk functionals because these quantities involve integrating products of densities with nonlinear functions that lack elementary antiderivatives. A *closed-form expression* is one that can be written finitely using a combination of elementary functions (polynomials, exponentials, logarithms, trigonometric functions, and their inverses); anything requiring infinite series or special functions that cannot be reduced to those building blocks falls outside the definition. For instance, the expected logistic activation under a Gaussian input,
+
+$$\mathbb{E}[\sigma(wX+b)] = \int_{-\infty}^{\infty} \frac{1}{1+e^{-(wx+b)}} \frac{1}{\sqrt{2\pi\sigma^2}} e^{-\frac{(x-\mu)^2}{2\sigma^2}}\, dx,$$
+
+has no closed-form solution for generic $(w,b,\mu,\sigma)$, even though both the logistic function and Gaussian density are fully specified. The integral can be expressed in terms of special functions such as the confluent hypergeometric function, but that still lies outside the elementary catalog and offers little computational advantage. In such cases we estimate the expectation (and its gradient with respect to $w$ and $b$) via Monte Carlo or quadrature. Sampling supplies approximations by turning integrals into averages, letting us stress-test models, calibrate parameters, and propagate uncertainty through downstream decisions. The more structure we impose (e.g., temporal dependence or spatial correlation), the more carefully our sampling strategies must mirror that structure.
 
 ### Why Sampling Matters in Practice
 


### PR DESCRIPTION
## Summary
- explain why closed-form expectations may be unavailable even for known distributions
- add Gaussian-logistic expectation example motivating Monte Carlo approximations
- clarify the definition of closed-form expressions by noting that special-function representations still fall outside the elementary catalog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df5bfde1588321b4fbb8c8c677f73a