### PR TITLE
Set Jekyll baseurl so blog links resolve correctly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,8 @@ kramdown:
   syntax_highlighter: rouge
 remote_theme: pages-themes/cayman@v0.2.0
 repository: atulsingh-nikki/obsidian-notes
+url: "https://atulsingh-nikki.github.io"
+baseurl: "/obsidian-notes"
 plugins:
   - jekyll-feed
   - jekyll-seo-tag


### PR DESCRIPTION
## Summary
- configure the Jekyll site with its production url and baseurl so generated links point to the GitHub Pages project path

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68e0e045214c832180a19ed17e55e600