### PR TITLE
Add blog landing page and guard bookshelf script

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -18,6 +18,9 @@ if (window.marked) {
 }
 
 async function init() {
+  if (!navigationEl || !contentEl || !mainEl) {
+    return;
+  }
   try {
     const books = await loadBooks();
     state.books = books;
@@ -215,5 +218,7 @@ function handleHashChange() {
   displayChapter(path);
 }
 
-window.addEventListener("hashchange", handleHashChange);
-document.addEventListener("DOMContentLoaded", init);
+if (navigationEl && contentEl && mainEl) {
+  window.addEventListener("hashchange", handleHashChange);
+  document.addEventListener("DOMContentLoaded", init);
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -906,3 +906,145 @@ article .blog-post__content {
     padding: 2rem 1rem 3rem;
   }
 }
+
+/* Blog index page */
+.blog-page {
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  padding: 2.5rem 2rem 3rem;
+}
+
+.blog-page__main {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+  margin: 0 auto;
+  max-width: 95%;
+  padding: 2.5rem 3rem;
+}
+
+.blog-page__header {
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.75rem;
+}
+
+.blog-page__header h1 {
+  font-size: clamp(2rem, 3vw, 2.75rem);
+  margin: 0 0 0.75rem;
+}
+
+.blog-page__intro {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.blog-page__list {
+  counter-reset: post-count;
+  display: grid;
+  gap: 1.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.blog-page__item {
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  padding: 1.75rem 2rem;
+  position: relative;
+}
+
+.blog-page__item::before {
+  color: var(--accent);
+  content: counter(post-count, decimal-leading-zero);
+  counter-increment: post-count;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  position: absolute;
+  right: 1.75rem;
+  top: 1.75rem;
+}
+
+.blog-page__item-title {
+  font-size: 1.4rem;
+  margin: 0 0 0.75rem;
+}
+
+.blog-page__item-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-page__item-title a:hover,
+.blog-page__item-title a:focus {
+  color: var(--accent);
+}
+
+.blog-page__item-meta {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  margin: 0 0 0.85rem;
+}
+
+.blog-page__item-tags {
+  font-style: italic;
+}
+
+.blog-page__item-excerpt {
+  margin: 0 0 1.25rem;
+}
+
+.blog-page__item-read-more {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.blog-page__item-read-more:hover,
+.blog-page__item-read-more:focus {
+  text-decoration: underline;
+}
+
+.blog-page__empty {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+}
+
+@media screen and (max-width: 56em) {
+  .blog-page {
+    padding: 2rem 1.25rem 2.5rem;
+  }
+
+  .blog-page__main {
+    padding: 2rem 1.75rem;
+  }
+
+  .blog-page__item {
+    padding: 1.5rem 1.5rem 1.75rem;
+  }
+
+  .blog-page__item::before {
+    right: 1.5rem;
+    top: 1.5rem;
+  }
+}
+
+@media screen and (prefers-color-scheme: dark) {
+  .blog-page {
+    --bg: #0b1120;
+    --bg-alt: #111827;
+    --border: rgba(148, 163, 184, 0.2);
+    --text: #e2e8f0;
+    --text-muted: #94a3b8;
+    --accent: #818cf8;
+    --accent-soft: rgba(129, 140, 248, 0.12);
+    --shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  }
+}

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,37 +1,51 @@
 ---
 layout: default
-title: "Blog"
+title: Blog
 permalink: /blog/
-description: "Short updates and essays that complement the long-form notes in the bookshelf."
+description: Updates, essays, and changelog notes from the Atul Singh Notes project.
 ---
 
-<section class="blog-index">
-  <header class="blog-index__header">
-    <h1>Blog</h1>
-    <p class="blog-index__description">
-      Short updates, context, and essays that complement the long-form notes in the bookshelf.
-    </p>
-  </header>
-
-  {%- if site.posts and site.posts.size > 0 -%}
-    <div class="blog-index__list">
-      {%- for post in site.posts -%}
-        <article class="blog-index__item">
-          <h2 class="blog-index__item-title">
-            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-          </h2>
-          <p class="blog-index__item-meta">
-            <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
-            {%- if post.tags and post.tags.size > 0 -%}
-              · <span class="blog-index__item-tags">{{ post.tags | join: ", " }}</span>
-            {%- endif -%}
-          </p>
-          <p class="blog-index__item-excerpt">{{ post.excerpt | strip_html | truncate: 180 }}</p>
-          <a class="blog-index__item-read-more" href="{{ post.url | relative_url }}">Read more →</a>
-        </article>
-      {%- endfor -%}
+<div class="blog-page">
+  <nav class="home-page__nav" aria-label="Primary">
+    <div class="home-page__nav-inner">
+      <a class="home-page__brand" href="{{ '/' | relative_url }}">Atul Singh Notes</a>
+      <ul class="home-page__nav-links">
+        <li><a href="{{ '/' | relative_url }}">Home</a></li>
+        <li><a href="{{ '/blog/' | relative_url }}" aria-current="page">Blog</a></li>
+      </ul>
     </div>
-  {%- else -%}
-    <p class="blog-index__empty">No posts yet. Check back soon for updates.</p>
-  {%- endif -%}
-</section>
+  </nav>
+
+  <main class="blog-page__main" id="main" tabindex="-1">
+    <header class="blog-page__header">
+      <h1>Blog</h1>
+      <p class="blog-page__intro">
+        Essays, changelog entries, and research updates that complement the long-form notes in the Learning Collection.
+      </p>
+    </header>
+
+    {% if site.posts and site.posts.size > 0 %}
+      <ol class="blog-page__list">
+        {% for post in site.posts %}
+          <li class="blog-page__item">
+            <article>
+              <h2 class="blog-page__item-title">
+                <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+              </h2>
+              <p class="blog-page__item-meta">
+                <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+                {% if post.tags and post.tags.size > 0 %}
+                  · <span class="blog-page__item-tags">{{ post.tags | join: ", " }}</span>
+                {% endif %}
+              </p>
+              <p class="blog-page__item-excerpt">{{ post.excerpt | strip_html | truncate: 220 }}</p>
+              <a class="blog-page__item-read-more" href="{{ post.url | relative_url }}">Read more →</a>
+            </article>
+          </li>
+        {% endfor %}
+      </ol>
+    {% else %}
+      <p class="blog-page__empty">No posts published yet. Check back soon for updates.</p>
+    {% endif %}
+  </main>
+</div>


### PR DESCRIPTION
## Summary
- replace the blog index with a full landing page that reuses the primary navigation and improves post presentation
- add styling for the new blog layout so the page matches the rest of the site in both light and dark modes
- guard the bookshelf loader script so it only runs on pages with the bookshelf UI, preventing stray fetches

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68e107ca40b083219600fc20f3a81274