### PR TITLE
Add research note: MDP — Multidimensional Vision Model Pruning with Latency Constraint (2025)

### DIFF
--- a/Research/2025/MDP Multidimensional Vision Model Pruning with Latency Constraint (2025).md
+++ b/Research/2025/MDP Multidimensional Vision Model Pruning with Latency Constraint (2025).md
@@ -1,0 +1,94 @@
+---
+title: "MDP: Multidimensional Vision Model Pruning with Latency Constraint (2025)"
+aliases:
+  - MDP Pruning
+  - Multidimensional Vision Model Pruning
+  - MDP 2025
+authors:
+  - Xinglong Sun
+  - Barath Lakshmanan
+  - Maying Shen
+  - Shiyi Lan
+  - Jingde Chen
+  - Jose M. Alvarez
+year: 2025
+venue: arXiv
+doi: 10.48550/arXiv.2504.02168
+arxiv: https://arxiv.org/abs/2504.02168
+code: ""
+citations: 0+
+tags:
+  - paper
+  - model-compression
+  - pruning
+  - latency-aware-optimization
+  - vision-transformers
+  - cnn
+fields:
+  - computer-vision
+  - efficient-ml
+  - optimization
+related:
+  - "[[Optimal Brain Damage (1989)]]"
+  - "[[Deep Compression Compressing Deep Neural Networks with Pruning, Trained Quantization and Huffman Coding (2015)|Deep Compression (2015)]]"
+predecessors:
+  - Latency-aware structural pruning methods (e.g., HALP, Isomorphic pruning)
+successors: []
+impact: ⭐⭐⭐⭐
+status: reading
+---
+
+# Summary
+**MDP (Multi-Dimensional Pruning)** introduces a unified pruning framework that optimizes multiple structural dimensions together (e.g., channels, attention heads, query/key dimensions, embeddings, and blocks) while enforcing an explicit latency target. Instead of relying on FLOPs or simple linear latency approximations, the method builds a more accurate latency model and solves pruning as a constrained optimization problem.
+
+# Key Idea
+> Treat network pruning as a **joint multi-dimensional optimization problem under real latency constraints**, not as independent one-dimensional sparsification.
+
+# Method
+- **Pruning space**: jointly searches over several architectural dimensions across both CNNs and Transformers.
+- **Latency modeling**: uses a richer latency estimator to capture non-linear interactions between pruned dimensions.
+- **Optimization formulation**: frames pruning as a **Mixed-Integer Nonlinear Program (MINLP)** to maximize accuracy subject to latency constraints.
+- **Deployment alignment**: explicitly targets wall-clock latency instead of proxy metrics alone.
+
+# Results (reported)
+- On **ImageNet / ResNet-50**, MDP reports about **28% speed-up** and **+1.4 top-1 accuracy** compared with prior latency-aware baselines such as HALP.
+- Against transformer pruning baselines (e.g., **Isomorphic**), MDP reports an additional **~37% acceleration** with **+0.7 top-1 accuracy**.
+- Gains are strongest in high-pruning/high-acceleration regimes where one-dimensional pruning often collapses.
+
+# Why It Matters
+- Moves pruning practice from “FLOPs reduction” to **hardware-relevant latency optimization**.
+- Handles **Transformer-specific coupling effects** (heads, Q/K dims, embeddings, blocks) that simple models miss.
+- Offers a shared framework across **CNN and ViT-style** architectures.
+
+# Strengths
+- Unified formulation for multiple pruning granularities.
+- Better trade-off between accuracy and runtime in constrained deployment settings.
+- Strong empirical improvements in aggressive compression regimes.
+
+# Limitations / Open Questions
+- MINLP-based search can be computationally expensive and sensitive to solver/config choices.
+- Latency model portability across hardware backends remains an open practical issue.
+- Reported gains depend on accurate profiling; mismatch between profiling and deployment stack can reduce benefits.
+
+# Practical Takeaways
+- For real-time vision deployment, optimize directly for **latency budgets** instead of only FLOPs/parameters.
+- Jointly pruning several dimensions can outperform channel-only or head-only pruning.
+- Profiling quality is critical: poor latency models can negate optimization gains.
+
+# Educational Connections
+## Undergraduate-level intuition
+- FLOPs are not the same as runtime.
+- Different model components (channels, heads, blocks) interact; removing one part can change the efficiency of others.
+
+## Graduate-level lens
+- Constrained architecture search with mixed discrete-continuous decisions.
+- MINLP as a principled way to encode combinatorial pruning under deployment constraints.
+- Multi-objective trade-off: accuracy vs latency under hardware-dependent response surfaces.
+
+# My Notes
+- This paper is a useful bridge between classic structural pruning and hardware-aware neural architecture optimization.
+- Key conceptual shift: optimize over **interacting dimensions jointly**; avoid independent greedy pruning passes.
+- Worth testing with quantization pipelines: MDP-style pruning + post-training quantization may yield better edge deployment points.
+
+# Citation
+Sun, X., Lakshmanan, B., Shen, M., Lan, S., Chen, J., & Alvarez, J. M. (2025). *MDP: Multidimensional Vision Model Pruning with Latency Constraint*. arXiv:2504.02168.


### PR DESCRIPTION
### Motivation
- Add a curated research note summarizing the 2025 MDP paper so the repository has a searchable, metadata-rich entry for model-compression and latency-aware pruning research.
- Capture the paper’s method, reported ImageNet/latency results, practical takeaways, and educational notes for later reference and comparisons.

### Description
- Added `Research/2025/MDP Multidimensional Vision Model Pruning with Latency Constraint (2025).md` containing frontmatter (title, authors, DOI/arXiv link, tags, fields) and a full write-up of summary, method, results, strengths, limitations, takeaways, and citation.
- Documented the core technical contributions: multi-dimensional pruning space (channels, heads, Q/K dims, embeddings, blocks), richer latency modeling, and MINLP optimization framing targeting wall-clock latency for both CNNs and Transformers.
- Linked related prior work and included practical/educational notes highlighting deployment implications and open questions.

### Testing
- Verified the new file is discoverable in the project tree using `rg --files` which listed the added research file, and the command completed successfully.
- Printed and inspected the note contents via `sed -n '1,220p' "Research/2025/MDP Multidimensional Vision Model Pruning with Latency Constraint (2025).md"` and `nl -ba` to confirm formatting and presence of expected sections, both commands succeeded.
- Queried arXiv metadata with a small Python script against the arXiv API to confirm title/authors/abstract and matched those details to the note, and the query returned the expected entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992efec3f508321a2a92f46c224c09b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a markdown research note; no production code or runtime behavior is modified.
> 
> **Overview**
> Adds a new research note, `Research/2025/MDP Multidimensional Vision Model Pruning with Latency Constraint (2025).md`, with metadata-rich frontmatter and a curated write-up summarizing the MDP paper.
> 
> The note captures the paper’s multi-dimensional, latency-constrained pruning approach (including MINLP framing), reported ImageNet/latency results, strengths/limitations, practical takeaways, and links to related prior work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd479eaa9f6f21bc2032a576b6a6b7ebb31de211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->